### PR TITLE
fix:  exclude blur event bubbled from item

### DIFF
--- a/src/Relect.js
+++ b/src/Relect.js
@@ -58,8 +58,10 @@ class Relect extends React.Component {
         this.props.onChange(null);
     };
 
-    onBlur = () => {
-        this.setState({ showMenu : false })
+    onBlur = (e) => {
+        if (e.target === e.currentTarget) {
+            this.setState({ showMenu : false })    
+        }
     };
 
     onKeyDown = e => {


### PR DESCRIPTION
React will bubble relect container's child <Menu> to container in IE 10~11（Other version not tested）.
There should be a check.